### PR TITLE
feat: add login authentication with SQLite + JWT

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,7 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           AWS_REGION: ${{ env.AWS_REGION }}
           LIGHTSAIL_INSTANCE_NAME: ${{ env.LIGHTSAIL_INSTANCE_NAME }}
+          SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
         run: |
           chmod +x ./scripts/deploy.sh
           ./scripts/deploy.sh --ci

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -42,7 +42,12 @@ jobs:
           # Install Copilot CLI extension
           gh extension install github/gh-copilot || true
 
-      - name: Run integration tests
+      - name: Run unit & auth integration tests
+        env:
+          SESSION_SECRET: ci-test-secret-not-for-production
+        run: npx jest --verbose
+
+      - name: Run Copilot SDK integration test
         env:
           # Authentication for GitHub Copilot SDK
           # The SDK checks these environment variables in order:
@@ -69,4 +74,5 @@ jobs:
           path: |
             *.log
             npm-debug.log*
+            data/*.db
           retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ dist/
 build/
 *.tsbuildinfo
 
+# SQLite database files
+data/*.db
+data/*.db-wal
+data/*.db-shm
+
 # Environment variables
 .env
 .env.local

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -21,6 +21,10 @@ module.exports = {
         // with COPILOT_GITHUB_TOKEN=ghp_xxxxx
         // Or export it before pm2 start
         COPILOT_GITHUB_TOKEN: process.env.COPILOT_GITHUB_TOKEN || '',
+        // Auth: JWT signing secret (required — generate with: openssl rand -hex 32)
+        SESSION_SECRET: process.env.SESSION_SECRET || '',
+        // Auth: SQLite database path
+        AUTH_DB_PATH: '/opt/bitnami/apps/moss-chat/data/auth.db',
       },
       // Logging
       error_file: '/opt/bitnami/apps/moss-chat/logs/error.log',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,18 @@
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "^0.1.23",
-        "express": "^4.18.2"
+        "argon2": "^0.44.0",
+        "better-sqlite3": "^12.6.2",
+        "cookie-parser": "^1.4.7",
+        "express": "^4.18.2",
+        "jsonwebtoken": "^9.0.3"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
+        "@types/cookie-parser": "^1.4.10",
         "@types/express": "^4.17.21",
         "@types/jest": "^30.0.0",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^24.0.0",
         "@types/supertest": "^6.0.3",
         "@typescript-eslint/eslint-plugin": "^6.15.0",
@@ -605,6 +612,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -2103,6 +2116,15 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2238,6 +2260,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -2257,6 +2289,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cookiejar": {
@@ -2344,6 +2386,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -2355,6 +2408,13 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3086,6 +3146,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argon2": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.44.0.tgz",
+      "integrity": "sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "cross-env": "^10.0.0",
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3229,6 +3305,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -3237,6 +3333,40 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
+      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -3358,6 +3488,36 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3470,6 +3630,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
@@ -3614,6 +3780,25 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
@@ -3634,11 +3819,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3667,6 +3868,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
@@ -3680,6 +3896,15 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -3726,6 +3951,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -3806,6 +4040,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3846,6 +4089,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/error-ex": {
@@ -4207,6 +4459,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
@@ -4377,6 +4638,12 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4545,6 +4812,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4668,6 +4941,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -4912,6 +5191,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4985,6 +5284,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -5083,7 +5388,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -5927,6 +6231,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5984,6 +6331,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5996,6 +6379,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -6151,6 +6540,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
@@ -6171,7 +6572,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6187,10 +6587,22 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {
@@ -6231,6 +6643,38 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -6297,7 +6741,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -6451,7 +6894,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6643,6 +7085,33 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6692,6 +7161,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -6781,12 +7260,50 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -6923,7 +7440,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6996,7 +7512,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7009,7 +7524,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7094,6 +7608,51 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7162,6 +7721,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -7355,6 +7923,34 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/test-exclude": {
@@ -7583,6 +8179,18 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7752,6 +8360,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -7826,7 +8440,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7896,7 +8509,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:integration": "node src/copilot-integration.test.mjs",
-    "test:integration:semantic": "node src/copilot-semantic-search-integration.test.mjs"
+    "test:integration:semantic": "node src/copilot-semantic-search-integration.test.mjs",
+    "seed": "tsx scripts/seed-users.ts"
   },
   "keywords": [
     "typescript",
@@ -26,11 +27,18 @@
   "license": "MIT",
   "dependencies": {
     "@github/copilot-sdk": "^0.1.23",
-    "express": "^4.18.2"
+    "argon2": "^0.44.0",
+    "better-sqlite3": "^12.6.2",
+    "cookie-parser": "^1.4.7",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.3"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/cookie-parser": "^1.4.10",
     "@types/express": "^4.17.21",
     "@types/jest": "^30.0.0",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^24.0.0",
     "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^6.15.0",

--- a/public/index.html
+++ b/public/index.html
@@ -24,12 +24,31 @@
             background-color: #252526;
             padding: 1rem 1.5rem;
             border-bottom: 1px solid #3e3e42;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
         }
 
         .header h1 {
             font-size: 1.5rem;
             font-weight: 600;
             color: #cccccc;
+        }
+
+        .logout-button {
+            background-color: transparent;
+            color: #858585;
+            border: 1px solid #3e3e42;
+            padding: 0.4rem 0.75rem;
+            border-radius: 4px;
+            font-size: 0.8rem;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .logout-button:hover {
+            color: #d4d4d4;
+            border-color: #858585;
         }
 
         .chat-container {
@@ -237,6 +256,7 @@
 <body>
     <div class="header">
         <h1>Moss Chat</h1>
+        <button class="logout-button" id="logoutButton">Sign Out</button>
     </div>
 
     <div class="chat-container">
@@ -261,6 +281,27 @@
     </div>
 
     <script>
+        // Auth check — redirect to login if not authenticated
+        fetch('/api/auth/status')
+            .then(res => {
+                if (!res.ok) {
+                    window.location.href = '/login.html';
+                }
+            })
+            .catch(() => {
+                window.location.href = '/login.html';
+            });
+
+        // Logout handler
+        document.getElementById('logoutButton').addEventListener('click', async () => {
+            try {
+                await fetch('/api/logout', { method: 'POST' });
+            } catch (e) {
+                // Ignore network errors during logout
+            }
+            window.location.href = '/login.html';
+        });
+
         const messagesArea = document.getElementById('messagesArea');
 
         // Configure marked with safe defaults
@@ -386,6 +427,10 @@
                 });
 
                 if (!response.ok) {
+                    if (response.status === 401) {
+                        window.location.href = '/login.html';
+                        return;
+                    }
                     throw new Error('Failed to get response from server');
                 }
 

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Moss Chat - Login</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica', 'Arial', sans-serif;
+            background-color: #1e1e1e;
+            color: #d4d4d4;
+            height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .login-container {
+            background-color: #252526;
+            border: 1px solid #3e3e42;
+            border-radius: 12px;
+            padding: 2.5rem;
+            width: 100%;
+            max-width: 400px;
+            margin: 1rem;
+        }
+
+        .login-header {
+            text-align: center;
+            margin-bottom: 2rem;
+        }
+
+        .login-header h1 {
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: #cccccc;
+            margin-bottom: 0.5rem;
+        }
+
+        .login-header p {
+            font-size: 0.9rem;
+            color: #858585;
+        }
+
+        .form-group {
+            margin-bottom: 1.25rem;
+        }
+
+        .form-group label {
+            display: block;
+            margin-bottom: 0.5rem;
+            font-size: 0.875rem;
+            color: #cccccc;
+            font-weight: 500;
+        }
+
+        .form-group input {
+            width: 100%;
+            padding: 0.75rem 1rem;
+            background-color: #3c3c3c;
+            border: 1px solid #3e3e42;
+            border-radius: 6px;
+            color: #d4d4d4;
+            font-size: 0.95rem;
+            font-family: inherit;
+            transition: border-color 0.2s;
+        }
+
+        .form-group input:focus {
+            outline: none;
+            border-color: #0e639c;
+        }
+
+        .form-group input::placeholder {
+            color: #6e6e6e;
+        }
+
+        .login-button {
+            width: 100%;
+            padding: 0.75rem;
+            background-color: #0e639c;
+            color: #ffffff;
+            border: none;
+            border-radius: 6px;
+            font-size: 1rem;
+            font-weight: 500;
+            cursor: pointer;
+            transition: background-color 0.2s;
+            margin-top: 0.5rem;
+        }
+
+        .login-button:hover:not(:disabled) {
+            background-color: #1177bb;
+        }
+
+        .login-button:disabled {
+            background-color: #3e3e42;
+            cursor: not-allowed;
+            opacity: 0.6;
+        }
+
+        .error-message {
+            background-color: rgba(220, 53, 69, 0.15);
+            border: 1px solid rgba(220, 53, 69, 0.3);
+            color: #f48771;
+            padding: 0.75rem 1rem;
+            border-radius: 6px;
+            font-size: 0.875rem;
+            margin-bottom: 1rem;
+            display: none;
+        }
+
+        .error-message.visible {
+            display: block;
+        }
+    </style>
+</head>
+<body>
+    <div class="login-container">
+        <div class="login-header">
+            <h1>🌿 Moss Chat</h1>
+            <p>Sign in to continue</p>
+        </div>
+
+        <div class="error-message" id="errorMessage"></div>
+
+        <form id="loginForm" novalidate>
+            <div class="form-group">
+                <label for="email">Email</label>
+                <input
+                    type="email"
+                    id="email"
+                    name="email"
+                    placeholder="you@example.com"
+                    autocomplete="email"
+                    required
+                    aria-label="Email address">
+            </div>
+
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input
+                    type="password"
+                    id="password"
+                    name="password"
+                    placeholder="Enter your password"
+                    autocomplete="current-password"
+                    required
+                    aria-label="Password">
+            </div>
+
+            <button type="submit" class="login-button" id="loginButton">Sign In</button>
+        </form>
+    </div>
+
+    <script>
+        const loginForm = document.getElementById('loginForm');
+        const emailInput = document.getElementById('email');
+        const passwordInput = document.getElementById('password');
+        const loginButton = document.getElementById('loginButton');
+        const errorMessage = document.getElementById('errorMessage');
+
+        /**
+         * Hashes a string with SHA-256 using the Web Crypto API.
+         * Returns the hex-encoded digest.
+         * @param {string} message - The plaintext to hash
+         * @returns {Promise<string>} Hex-encoded SHA-256 digest
+         */
+        async function sha256(message) {
+            const encoder = new TextEncoder();
+            const data = encoder.encode(message);
+            const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+            const hashArray = Array.from(new Uint8Array(hashBuffer));
+            return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+        }
+
+        /**
+         * Shows an error message to the user.
+         * @param {string} msg - The error text
+         */
+        function showError(msg) {
+            errorMessage.textContent = msg;
+            errorMessage.classList.add('visible');
+        }
+
+        /**
+         * Hides the error message.
+         */
+        function hideError() {
+            errorMessage.classList.remove('visible');
+        }
+
+        // If already authenticated, redirect to chat
+        fetch('/api/auth/status')
+            .then(res => {
+                if (res.ok) {
+                    window.location.href = '/';
+                }
+            })
+            .catch(() => { /* not authenticated, stay on login */ });
+
+        loginForm.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            hideError();
+
+            const email = emailInput.value.trim();
+            const password = passwordInput.value;
+
+            if (!email || !password) {
+                showError('Please enter both email and password.');
+                return;
+            }
+
+            // Basic client-side email check
+            if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+                showError('Please enter a valid email address.');
+                return;
+            }
+
+            loginButton.disabled = true;
+            loginButton.textContent = 'Signing in...';
+
+            try {
+                // Hash password client-side before sending
+                const passwordHash = await sha256(password);
+
+                const response = await fetch('/api/login', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ email, passwordHash }),
+                });
+
+                const data = await response.json();
+
+                if (response.ok) {
+                    window.location.href = '/';
+                } else {
+                    showError(data.error || 'Login failed. Please try again.');
+                }
+            } catch (error) {
+                showError('Unable to connect to the server. Please try again.');
+            } finally {
+                loginButton.disabled = false;
+                loginButton.textContent = 'Sign In';
+            }
+        });
+
+        // Focus email input on load
+        emailInput.focus();
+    </script>
+</body>
+</html>

--- a/scripts/seed-users.ts
+++ b/scripts/seed-users.ts
@@ -1,0 +1,133 @@
+/**
+ * Seed script — creates initial users in the auth database.
+ *
+ * Generates a random password for each user, hashes it the same way
+ * the client + server would (SHA-256 → argon2), inserts into the DB,
+ * and prints the plaintext passwords to stdout so the admin can save them.
+ *
+ * Usage:
+ *   npx tsx scripts/seed-users.ts
+ *
+ * Environment:
+ *   AUTH_DB_PATH — optional, defaults to ./data/auth.db
+ *
+ * @module seed-users
+ */
+
+import crypto from 'crypto';
+import argon2 from 'argon2';
+import Database from 'better-sqlite3';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/** Users to seed */
+const SEED_USERS = [
+  { email: 'ci-system@gmail.com', role: 'CI system' },
+  { email: 'garlandk@gmail.com', role: 'Regular user' },
+];
+
+/**
+ * Generates a cryptographically random password.
+ * @param length - Password length (default 20)
+ * @returns A random alphanumeric password string
+ */
+function generatePassword(length = 20): string {
+  const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%&*';
+  const bytes = crypto.randomBytes(length);
+  return Array.from(bytes)
+    .map((b) => chars[b % chars.length])
+    .join('');
+}
+
+/**
+ * Mimics the client-side SHA-256 hash step.
+ * @param plaintext - The raw password string
+ * @returns Hex-encoded SHA-256 digest
+ */
+function sha256(plaintext: string): string {
+  return crypto.createHash('sha256').update(plaintext).digest('hex');
+}
+
+async function main(): Promise<void> {
+  const dbPath = process.env.AUTH_DB_PATH || path.join(__dirname, '../data/auth.db');
+
+  // Ensure data directory exists
+  const dataDir = path.dirname(dbPath);
+  if (!fs.existsSync(dataDir)) {
+    fs.mkdirSync(dataDir, { recursive: true });
+  }
+
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+
+  // Create users table if it doesn't exist
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT NOT NULL UNIQUE COLLATE NOCASE,
+      password_hash TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO users (email, password_hash) VALUES (?, ?)
+  `);
+
+  console.log('');
+  console.log('='.repeat(60));
+  console.log('  Moss Chat — User Seed');
+  console.log('='.repeat(60));
+  console.log('');
+
+  let seeded = 0;
+
+  for (const user of SEED_USERS) {
+    // Check if user already exists
+    const existing = db
+      .prepare('SELECT id FROM users WHERE email = ?')
+      .get(user.email) as { id: number } | undefined;
+
+    if (existing) {
+      console.log(`  ⏭  ${user.email} (${user.role}) — already exists, skipping`);
+      continue;
+    }
+
+    const password = generatePassword();
+    const clientHash = sha256(password);
+    const serverHash = await argon2.hash(clientHash);
+
+    const result = insert.run(user.email, serverHash);
+
+    if (result.changes > 0) {
+      console.log(`  ✅ ${user.email} (${user.role})`);
+      console.log(`     Password: ${password}`);
+      console.log('');
+      seeded++;
+    }
+  }
+
+  if (seeded === 0) {
+    console.log('  No new users to seed — all users already exist.');
+  } else {
+    console.log('-'.repeat(60));
+    console.log('  ⚠️  SAVE THESE PASSWORDS NOW — they cannot be recovered.');
+    console.log('-'.repeat(60));
+  }
+
+  console.log('');
+  console.log(`  Database: ${dbPath}`);
+  console.log('');
+
+  db.close();
+}
+
+main().catch((err) => {
+  console.error('Seed failed:', err);
+  process.exit(1);
+});

--- a/src/auth-integration.test.ts
+++ b/src/auth-integration.test.ts
@@ -1,0 +1,235 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/**
+ * Integration tests for the authentication flow
+ *
+ * Exercises the full HTTP lifecycle through the Express server:
+ *   - Unauthenticated requests are rejected (401 / redirect)
+ *   - Login with valid credentials returns a session cookie
+ *   - Authenticated requests succeed
+ *   - Logout clears the session
+ *   - Post-logout requests are rejected again
+ *
+ * Uses supertest so no real server port is needed.
+ * Mocks the Copilot SDK since we're testing auth, not AI.
+ */
+
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import supertest from 'supertest';
+
+// ---------- Environment setup (before importing server) ----------
+
+const TEST_SECRET = 'integration-test-secret-for-auth-flow';
+const TEST_DB_PATH = path.join(__dirname, '../data/test-auth-integration.db');
+
+process.env.SESSION_SECRET = TEST_SECRET;
+process.env.AUTH_DB_PATH = TEST_DB_PATH;
+process.env.NODE_ENV = 'test';
+
+// Mock the Copilot SDK so the server can import without real auth
+jest.mock('@github/copilot-sdk', () => ({
+  CopilotClient: jest.fn().mockImplementation(() => ({
+    start: jest.fn().mockResolvedValue(undefined),
+    stop: jest.fn().mockResolvedValue(undefined),
+    createSession: jest.fn().mockResolvedValue({
+      sendAndWait: jest.fn().mockResolvedValue({
+        data: { content: 'Mock AI response for auth integration test.' },
+      }),
+    }),
+  })),
+}));
+
+// Now import auth modules and the app
+import { getDb, closeDb } from './db.js';
+import { hashPassword } from './auth-service.js';
+import { app } from './server.js';
+
+const TEST_EMAIL = 'integration@example.com';
+const TEST_PASSWORD = 'my-secure-test-password';
+
+/**
+ * Mimics the client-side SHA-256 hash.
+ */
+function sha256(plain: string): string {
+  return crypto.createHash('sha256').update(plain).digest('hex');
+}
+
+// ---------- Setup / Teardown ----------
+
+beforeAll(async () => {
+  // Clean slate
+  if (fs.existsSync(TEST_DB_PATH)) {
+    fs.unlinkSync(TEST_DB_PATH);
+  }
+
+  // Initialise DB + seed a test user
+  const db = getDb();
+  const clientHash = sha256(TEST_PASSWORD);
+  const serverHash = await hashPassword(clientHash);
+  db.prepare('INSERT INTO users (email, password_hash) VALUES (?, ?)').run(
+    TEST_EMAIL,
+    serverHash
+  );
+});
+
+afterAll(() => {
+  closeDb();
+  // Clean up test database
+  for (const ext of ['', '-wal', '-shm']) {
+    const f = TEST_DB_PATH + ext;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+});
+
+// ---------- Helpers ----------
+
+/**
+ * Extracts the moss_session cookie value from a supertest response.
+ */
+function getSessionCookie(res: supertest.Response): string | undefined {
+  const raw = res.headers['set-cookie'];
+  const cookies = (Array.isArray(raw) ? raw : [raw]) as string[];
+  if (!cookies || cookies.length === 0) return undefined;
+  const match = cookies
+    .find((c: string) => c.startsWith('moss_session='));
+  if (!match) return undefined;
+  return match.split(';')[0].split('=').slice(1).join('=');
+}
+
+// ---------- Tests ----------
+
+describe('Auth integration flow', () => {
+  let sessionCookie: string;
+
+  it('GET / should redirect to /login.html when not authenticated', async () => {
+    const res = await supertest(app).get('/');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/login.html');
+  });
+
+  it('GET /api/auth/status should return 401 when not authenticated', async () => {
+    const res = await supertest(app).get('/api/auth/status');
+    expect(res.status).toBe(401);
+    expect(res.body.authenticated).toBe(false);
+  });
+
+  it('POST /api/chat should return 401 when not authenticated', async () => {
+    const res = await supertest(app)
+      .post('/api/chat')
+      .send({ message: 'hello' });
+    expect(res.status).toBe(401);
+  });
+
+  it('POST /api/login should return 400 for missing fields', async () => {
+    const res = await supertest(app)
+      .post('/api/login')
+      .send({ email: TEST_EMAIL });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /api/login should return 400 for invalid email format', async () => {
+    const res = await supertest(app)
+      .post('/api/login')
+      .send({ email: 'not-an-email', passwordHash: sha256('password') });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /api/login should return 401 for wrong password', async () => {
+    const res = await supertest(app)
+      .post('/api/login')
+      .send({ email: TEST_EMAIL, passwordHash: sha256('wrong-password') });
+    expect(res.status).toBe(401);
+  });
+
+  it('POST /api/login should return 401 for non-existent user', async () => {
+    const res = await supertest(app)
+      .post('/api/login')
+      .send({ email: 'nobody@example.com', passwordHash: sha256(TEST_PASSWORD) });
+    expect(res.status).toBe(401);
+  });
+
+  it('POST /api/login should succeed with valid credentials and set cookie', async () => {
+    const res = await supertest(app)
+      .post('/api/login')
+      .send({ email: TEST_EMAIL, passwordHash: sha256(TEST_PASSWORD) });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    // Verify cookie is set
+    const cookie = getSessionCookie(res);
+    expect(cookie).toBeDefined();
+    expect(cookie!.length).toBeGreaterThan(0);
+
+    // Verify cookie attributes
+    const rawCookies = res.headers['set-cookie'];
+    const allCookies = (Array.isArray(rawCookies) ? rawCookies : [rawCookies]) as string[];
+    const cookieHeader = allCookies
+      .find((c: string) => c.startsWith('moss_session='))!;
+    expect(cookieHeader).toContain('HttpOnly');
+    expect(cookieHeader).toContain('SameSite=Strict');
+    expect(cookieHeader).toContain('Path=/');
+
+    sessionCookie = cookie!;
+  });
+
+  it('GET /api/auth/status should return 200 with valid cookie', async () => {
+    const res = await supertest(app)
+      .get('/api/auth/status')
+      .set('Cookie', `moss_session=${sessionCookie}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.authenticated).toBe(true);
+    expect(res.body.email).toBe(TEST_EMAIL);
+  });
+
+  it('POST /api/login should be case-insensitive for email', async () => {
+    const res = await supertest(app)
+      .post('/api/login')
+      .send({ email: TEST_EMAIL.toUpperCase(), passwordHash: sha256(TEST_PASSWORD) });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('POST /api/logout should clear the session cookie', async () => {
+    const res = await supertest(app)
+      .post('/api/logout')
+      .set('Cookie', `moss_session=${sessionCookie}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    // Cookie should be cleared (set to empty with past expiry)
+    const rawCookies = res.headers['set-cookie'];
+    const allCookies = (Array.isArray(rawCookies) ? rawCookies : [rawCookies]) as string[];
+    const cookieHeader = allCookies
+      .find((c: string) => c.startsWith('moss_session='));
+    expect(cookieHeader).toBeDefined();
+  });
+
+  it('GET /api/auth/status should return 401 after logout (no cookie)', async () => {
+    const res = await supertest(app).get('/api/auth/status');
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /api/auth/status should return 401 with a tampered token', async () => {
+    const res = await supertest(app)
+      .get('/api/auth/status')
+      .set('Cookie', 'moss_session=this.is.not.a.valid.jwt');
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /api/health should be accessible without authentication', async () => {
+    const res = await supertest(app).get('/api/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+  });
+
+  it('GET /login.html should be accessible without authentication', async () => {
+    const res = await supertest(app).get('/login.html');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+  });
+});

--- a/src/auth-middleware.ts
+++ b/src/auth-middleware.ts
@@ -1,0 +1,112 @@
+/**
+ * Authentication middleware
+ *
+ * Reads the JWT from the `moss_session` HTTP-only cookie and attaches
+ * the decoded user payload to `req.user`. Returns 401 for unauthenticated
+ * requests.
+ *
+ * Also exports a simple in-memory rate limiter for login attempts.
+ *
+ * @module auth-middleware
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { verifyToken, TokenPayload } from './auth-service.js';
+
+/** Cookie name used for the session JWT */
+export const SESSION_COOKIE = 'moss_session';
+
+/** Extend Express Request to include the authenticated user */
+/* eslint-disable @typescript-eslint/no-namespace */
+declare global {
+  namespace Express {
+    interface Request {
+      user?: TokenPayload;
+    }
+  }
+}
+/* eslint-enable @typescript-eslint/no-namespace */
+
+/**
+ * Express middleware that requires a valid JWT in the session cookie.
+ * On success, sets `req.user` and calls `next()`.
+ * On failure, responds with 401.
+ *
+ * @param req - Express request
+ * @param res - Express response
+ * @param next - Express next function
+ */
+export function requireAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const token = req.cookies?.[SESSION_COOKIE] as string | undefined;
+
+  if (!token) {
+    res.status(401).json({ error: 'Authentication required' });
+    return;
+  }
+
+  const payload = verifyToken(token);
+  if (!payload) {
+    res.status(401).json({ error: 'Invalid or expired session' });
+    return;
+  }
+
+  req.user = payload;
+  next();
+}
+
+// ---------------------------------------------------------------------------
+// Simple in-memory rate limiter for login attempts
+// ---------------------------------------------------------------------------
+
+interface RateBucket {
+  count: number;
+  resetAt: number;
+}
+
+/** Map of IP → rate bucket */
+const loginAttempts = new Map<string, RateBucket>();
+
+/** Max login attempts per window */
+const MAX_ATTEMPTS = 10;
+
+/** Window duration in milliseconds (15 minutes) */
+const WINDOW_MS = 15 * 60 * 1000;
+
+/**
+ * Rate-limit middleware for login endpoint.
+ * Allows {@link MAX_ATTEMPTS} attempts per IP per {@link WINDOW_MS} window.
+ *
+ * @param req - Express request
+ * @param res - Express response
+ * @param next - Express next function
+ */
+export function loginRateLimiter(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const ip = req.ip ?? 'unknown';
+  const now = Date.now();
+
+  const bucket = loginAttempts.get(ip);
+
+  if (!bucket || now > bucket.resetAt) {
+    loginAttempts.set(ip, { count: 1, resetAt: now + WINDOW_MS });
+    next();
+    return;
+  }
+
+  if (bucket.count >= MAX_ATTEMPTS) {
+    const retryAfterSec = Math.ceil((bucket.resetAt - now) / 1000);
+    res.setHeader('Retry-After', String(retryAfterSec));
+    res.status(429).json({ error: 'Too many login attempts. Please try again later.' });
+    return;
+  }
+
+  bucket.count += 1;
+  next();
+}

--- a/src/auth-routes.ts
+++ b/src/auth-routes.ts
@@ -1,0 +1,117 @@
+/**
+ * Authentication routes
+ *
+ * Provides login, logout, and auth-status endpoints.
+ *
+ * @module auth-routes
+ */
+
+import { Router, Request, Response } from 'express';
+import { verifyLogin, verifyToken } from './auth-service.js';
+import { SESSION_COOKIE, loginRateLimiter } from './auth-middleware.js';
+
+/** 30 days in milliseconds */
+const COOKIE_MAX_AGE = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Request body for the login endpoint
+ */
+interface LoginBody {
+  email: string;
+  passwordHash: string;
+}
+
+/**
+ * Creates and returns the auth Router.
+ * @returns Express Router with /api/login, /api/logout, /api/auth/status
+ */
+export function createAuthRouter(): Router {
+  const router = Router();
+
+  /**
+   * POST /api/login
+   * Authenticates a user with email + client-side SHA-256 password hash.
+   * On success, sets an HTTP-only cookie with a 30-day JWT.
+   */
+  router.post(
+    '/api/login',
+    loginRateLimiter,
+    async (req: Request<object, unknown, LoginBody>, res: Response) => {
+      const { email, passwordHash } = req.body;
+
+      if (!email || !passwordHash) {
+        res.status(400).json({ error: 'Email and password are required' });
+        return;
+      }
+
+      // Basic email format validation
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      if (!emailRegex.test(email)) {
+        res.status(400).json({ error: 'Invalid email format' });
+        return;
+      }
+
+      try {
+        const token = await verifyLogin(email, passwordHash);
+
+        if (!token) {
+          res.status(401).json({ error: 'Invalid email or password' });
+          return;
+        }
+
+        // Set HTTP-only, secure cookie
+        res.cookie(SESSION_COOKIE, token, {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production',
+          sameSite: 'strict',
+          maxAge: COOKIE_MAX_AGE,
+          path: '/',
+        });
+
+        res.json({ success: true });
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Login error:', error);
+        res.status(500).json({ error: 'An error occurred during login' });
+      }
+    }
+  );
+
+  /**
+   * POST /api/logout
+   * Clears the session cookie.
+   */
+  router.post('/api/logout', (_req: Request, res: Response) => {
+    res.clearCookie(SESSION_COOKIE, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      path: '/',
+    });
+    res.json({ success: true });
+  });
+
+  /**
+   * GET /api/auth/status
+   * Returns 200 if the session cookie contains a valid JWT, 401 otherwise.
+   * Used by the frontend on page load to decide whether to show the chat or redirect to login.
+   */
+  router.get('/api/auth/status', (req: Request, res: Response) => {
+    const token = req.cookies?.[SESSION_COOKIE] as string | undefined;
+
+    if (!token) {
+      res.status(401).json({ authenticated: false });
+      return;
+    }
+
+    const payload = verifyToken(token);
+    if (!payload) {
+      res.status(401).json({ authenticated: false });
+      return;
+    }
+
+    res.json({ authenticated: true, email: payload.email });
+  });
+
+  return router;
+}

--- a/src/auth-service.test.ts
+++ b/src/auth-service.test.ts
@@ -1,0 +1,249 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/**
+ * Unit tests for the authentication layer
+ *
+ * Tests cover:
+ *  - Password hashing (hashPassword)
+ *  - Login verification (verifyLogin)
+ *  - JWT creation and validation (verifyToken)
+ *  - requireAuth middleware
+ *  - loginRateLimiter middleware
+ */
+
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { Request, Response } from 'express';
+
+// ---------- Environment setup (must come before importing auth modules) ----------
+
+const TEST_SECRET = 'test-secret-key-for-unit-tests-only';
+const TEST_DB_PATH = path.join(__dirname, '../data/test-auth.db');
+
+// Set env vars before importing modules that read them at load time
+process.env.SESSION_SECRET = TEST_SECRET;
+process.env.AUTH_DB_PATH = TEST_DB_PATH;
+
+// Now import auth modules
+import { verifyLogin, verifyToken, hashPassword } from './auth-service.js';
+import { requireAuth, loginRateLimiter } from './auth-middleware.js';
+import { closeDb, getDb } from './db.js';
+
+// ---------- Helpers ----------
+
+/**
+ * Mimics the client-side SHA-256 hash.
+ */
+function sha256(plain: string): string {
+  return crypto.createHash('sha256').update(plain).digest('hex');
+}
+
+/**
+ * Creates a mock Express request with optional overrides.
+ */
+function mockRequest(overrides: Partial<Request> = {}): Request {
+  return {
+    cookies: {},
+    ip: '127.0.0.1',
+    ...overrides,
+  } as unknown as Request;
+}
+
+/**
+ * Creates a mock Express response that captures status codes and JSON bodies.
+ */
+function mockResponse(): Response & { _status: number; _json: unknown; _headers: Record<string, string> } {
+  const res: { _status: number; _json: unknown; _headers: Record<string, string>; status: (code: number) => typeof res; json: (body: unknown) => typeof res; setHeader: (name: string, value: string) => typeof res } = {
+    _status: 200,
+    _json: null as unknown,
+    _headers: {} as Record<string, string>,
+    status(code: number) {
+      res._status = code;
+      return res;
+    },
+    json(body: unknown) {
+      res._json = body;
+      return res;
+    },
+    setHeader(name: string, value: string) {
+      res._headers[name] = value;
+      return res;
+    },
+  };
+  return res as unknown as Response & { _status: number; _json: unknown; _headers: Record<string, string> };
+}
+
+// ---------- Setup / Teardown ----------
+
+beforeAll(async () => {
+  // Ensure clean database
+  if (fs.existsSync(TEST_DB_PATH)) {
+    fs.unlinkSync(TEST_DB_PATH);
+  }
+
+  // Initialise DB + seed one test user
+  const db = getDb();
+  const clientHash = sha256('test-password-123');
+  const serverHash = await hashPassword(clientHash);
+  db.prepare('INSERT INTO users (email, password_hash) VALUES (?, ?)').run(
+    'test@example.com',
+    serverHash
+  );
+});
+
+afterAll(() => {
+  closeDb();
+  // Clean up test database
+  if (fs.existsSync(TEST_DB_PATH)) {
+    fs.unlinkSync(TEST_DB_PATH);
+  }
+  const walPath = TEST_DB_PATH + '-wal';
+  const shmPath = TEST_DB_PATH + '-shm';
+  if (fs.existsSync(walPath)) fs.unlinkSync(walPath);
+  if (fs.existsSync(shmPath)) fs.unlinkSync(shmPath);
+});
+
+// ---------- Tests ----------
+
+describe('hashPassword', () => {
+  it('should return an argon2 hash string', async () => {
+    const hash = await hashPassword('some-sha256-hex');
+    expect(hash).toMatch(/^\$argon2/);
+  });
+
+  it('should produce different hashes for the same input (random salt)', async () => {
+    const hash1 = await hashPassword('same-input');
+    const hash2 = await hashPassword('same-input');
+    expect(hash1).not.toBe(hash2);
+  });
+});
+
+describe('verifyLogin', () => {
+  it('should return a JWT for valid credentials', async () => {
+    const clientHash = sha256('test-password-123');
+    const token = await verifyLogin('test@example.com', clientHash);
+
+    expect(token).toBeTruthy();
+    expect(typeof token).toBe('string');
+  });
+
+  it('should return null for wrong password', async () => {
+    const clientHash = sha256('wrong-password');
+    const token = await verifyLogin('test@example.com', clientHash);
+
+    expect(token).toBeNull();
+  });
+
+  it('should return null for non-existent user', async () => {
+    const clientHash = sha256('any-password');
+    const token = await verifyLogin('nobody@example.com', clientHash);
+
+    expect(token).toBeNull();
+  });
+
+  it('should be case-insensitive for email', async () => {
+    const clientHash = sha256('test-password-123');
+    const token = await verifyLogin('TEST@EXAMPLE.COM', clientHash);
+
+    expect(token).toBeTruthy();
+  });
+});
+
+describe('verifyToken', () => {
+  it('should decode a valid token', async () => {
+    const clientHash = sha256('test-password-123');
+    const token = await verifyLogin('test@example.com', clientHash);
+
+    expect(token).not.toBeNull();
+    const payload = verifyToken(token!);
+
+    expect(payload).not.toBeNull();
+    expect(payload!.email).toBe('test@example.com');
+    expect(payload!.userId).toBeDefined();
+  });
+
+  it('should return null for an invalid token', () => {
+    const payload = verifyToken('not-a-real-token');
+    expect(payload).toBeNull();
+  });
+
+  it('should return null for an empty string', () => {
+    const payload = verifyToken('');
+    expect(payload).toBeNull();
+  });
+});
+
+describe('requireAuth middleware', () => {
+  it('should return 401 when no cookie is present', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const next = jest.fn();
+
+    requireAuth(req, res, next);
+
+    expect(res._status).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should return 401 for an invalid token', () => {
+    const req = mockRequest({ cookies: { moss_session: 'bad-token' } });
+    const res = mockResponse();
+    const next = jest.fn();
+
+    requireAuth(req, res, next);
+
+    expect(res._status).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should call next() and set req.user for a valid token', async () => {
+    const clientHash = sha256('test-password-123');
+    const token = await verifyLogin('test@example.com', clientHash);
+
+    const req = mockRequest({ cookies: { moss_session: token! } });
+    const res = mockResponse();
+    const next = jest.fn();
+
+    requireAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toBeDefined();
+    expect(req.user!.email).toBe('test@example.com');
+  });
+});
+
+describe('loginRateLimiter middleware', () => {
+  it('should allow requests under the limit', () => {
+    const req = mockRequest({ ip: '192.168.1.100' });
+    const res = mockResponse();
+    const next = jest.fn();
+
+    loginRateLimiter(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res._status).toBe(200);
+  });
+
+  it('should block after too many attempts', () => {
+    const ip = '10.0.0.99';
+    let next: jest.Mock;
+    let res: ReturnType<typeof mockResponse>;
+
+    // Make 10 requests (the limit)
+    for (let i = 0; i < 10; i++) {
+      const req = mockRequest({ ip });
+      res = mockResponse();
+      next = jest.fn();
+      loginRateLimiter(req, res, next);
+    }
+
+    // 11th should be blocked
+    const req = mockRequest({ ip });
+    res = mockResponse();
+    next = jest.fn();
+    loginRateLimiter(req, res, next);
+
+    expect(res._status).toBe(429);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/src/auth-service.ts
+++ b/src/auth-service.ts
@@ -1,0 +1,108 @@
+/**
+ * Authentication service
+ *
+ * Handles password verification and JWT token creation/validation.
+ *
+ * Password flow:
+ *   1. Client SHA-256 hashes the plaintext password (Web Crypto API)
+ *   2. Client sends the hex-encoded SHA-256 digest to the server
+ *   3. Server stores/verifies argon2(sha256hex)
+ *
+ * This ensures the raw password never travels over the wire, and the
+ * server stores a strong hash (argon2) of the client-side digest.
+ *
+ * @module auth-service
+ */
+
+import argon2 from 'argon2';
+import jwt from 'jsonwebtoken';
+import { getDb } from './db.js';
+
+/** JWT payload shape */
+export interface TokenPayload {
+  userId: number;
+  email: string;
+}
+
+/** User row from the database */
+interface UserRow {
+  id: number;
+  email: string;
+  password_hash: string;
+}
+
+/** Duration constants */
+const TOKEN_EXPIRY = '30d';
+
+/**
+ * Returns the JWT signing secret from the environment.
+ * Throws at call-time if not configured.
+ * @returns The secret string
+ * @throws Error if SESSION_SECRET is not set
+ */
+function getSecret(): string {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) {
+    throw new Error('SESSION_SECRET environment variable is required');
+  }
+  return secret;
+}
+
+/**
+ * Verifies a user's login credentials and returns a signed JWT.
+ *
+ * @param email - The user's email address
+ * @param clientHash - The SHA-256 hex digest of the user's password (produced client-side)
+ * @returns A signed JWT string, or null if credentials are invalid
+ */
+export async function verifyLogin(
+  email: string,
+  clientHash: string
+): Promise<string | null> {
+  const db = getDb();
+
+  const user = db
+    .prepare('SELECT id, email, password_hash FROM users WHERE email = ?')
+    .get(email) as UserRow | undefined;
+
+  if (!user) {
+    // Spend time hashing anyway to prevent timing-based user enumeration
+    await argon2.hash('dummy-value');
+    return null;
+  }
+
+  const valid = await argon2.verify(user.password_hash, clientHash);
+  if (!valid) {
+    return null;
+  }
+
+  const payload: TokenPayload = { userId: user.id, email: user.email };
+  const token = jwt.sign(payload, getSecret(), { expiresIn: TOKEN_EXPIRY });
+  return token;
+}
+
+/**
+ * Validates a JWT and returns the decoded payload, or null if invalid/expired.
+ *
+ * @param token - The JWT string from the cookie
+ * @returns The decoded TokenPayload, or null
+ */
+export function verifyToken(token: string): TokenPayload | null {
+  try {
+    const decoded = jwt.verify(token, getSecret()) as TokenPayload;
+    return decoded;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Hashes a client-side SHA-256 digest with argon2 for storage.
+ * Used by the seed script and (future) sign-up route.
+ *
+ * @param clientHash - The SHA-256 hex digest of the plaintext password
+ * @returns The argon2 hash string to store in the database
+ */
+export async function hashPassword(clientHash: string): Promise<string> {
+  return argon2.hash(clientHash);
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,66 @@
+/**
+ * SQLite database layer for authentication
+ *
+ * Uses better-sqlite3 which is a synchronous, file-based SQLite driver.
+ * The database file is only read when auth operations occur — no background
+ * process or persistent connection is needed.
+ *
+ * @module db
+ */
+
+import Database from 'better-sqlite3';
+import path from 'path';
+
+/** Singleton database instance */
+let db: Database.Database | null = null;
+
+/**
+ * Returns the path to the SQLite database file.
+ * Configurable via AUTH_DB_PATH environment variable.
+ * Falls back to data/auth.db relative to the project root (cwd).
+ * @returns The absolute path to the auth database file
+ */
+export function getDbPath(): string {
+  return process.env.AUTH_DB_PATH || path.join(process.cwd(), 'data', 'auth.db');
+}
+
+/**
+ * Initialises the SQLite database, creating the users table if it does not
+ * already exist. Returns the singleton database instance.
+ * @returns The better-sqlite3 Database instance
+ */
+export function getDb(): Database.Database {
+  if (db) {
+    return db;
+  }
+
+  const dbPath = getDbPath();
+  db = new Database(dbPath);
+
+  // Enable WAL mode for better concurrent read performance
+  db.pragma('journal_mode = WAL');
+
+  // Create users table if it doesn't exist
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT NOT NULL UNIQUE COLLATE NOCASE,
+      password_hash TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+
+  return db;
+}
+
+/**
+ * Closes the database connection and clears the singleton.
+ * Useful for tests and graceful shutdown.
+ */
+export function closeDb(): void {
+  if (db) {
+    db.close();
+    db = null;
+  }
+}


### PR DESCRIPTION
Add a login gate in front of the chat UI.

Backend:
- src/db.ts: SQLite via better-sqlite3 (file-based, no running DB process)
- src/auth-service.ts: argon2 password verification, JWT with 30-day expiry
- src/auth-middleware.ts: requireAuth + rate limiter (10 attempts/15 min/IP)
- src/auth-routes.ts: POST /api/login, POST /api/logout, GET /api/auth/status
- src/server.ts: cookie-parser, trust proxy, auth on /api/chat endpoints

Frontend:
- public/login.html: Dark-themed login with client-side SHA-256 hashing
- public/index.html: Auth check on load, 401 redirect

Infrastructure:
- scripts/seed-users.ts: Seeds two users with random passwords
- deploy.sh: Auto-seeds DB on first deploy, excludes auth.db from rsync
- deploy.yml: SESSION_SECRET from GitHub Actions secrets
- ecosystem.config.cjs: SESSION_SECRET and AUTH_DB_PATH env vars

Testing:
- src/auth-service.test.ts: 14 unit tests for auth layer